### PR TITLE
Fix potential bug in Concentrations and ReactionRates

### DIFF
--- a/source/concentrations.py
+++ b/source/concentrations.py
@@ -21,7 +21,7 @@ class Concentrations:
         Number of cells.
     n_nuc : int
         Number of nucs.
-    rates : np.array
+    number : np.array
         Array storing rates indexed by the above dictionaries.
     """
 
@@ -90,7 +90,7 @@ class Concentrations:
 
         Parameters
         ----------
-        pos : Tuple
+        pos : tuple
             A two-length tuple containing a cell index and a nuc index.  These
             indexes can be strings (which get converted to integers via the
             dictionaries), integers used directly, or slices.
@@ -109,7 +109,7 @@ class Concentrations:
         if isinstance(nuc, str):
             nuc_id = self.nuc_to_ind[nuc]
         else:
-            nuc_id = cell
+            nuc_id = nuc
 
         return self.number[cell_id, nuc_id]
 
@@ -118,7 +118,7 @@ class Concentrations:
 
         Parameters
         ----------
-        pos : Tuple
+        pos : tuple
             A two-length tuple containing a cell index and a nuc index.  These
             indexes can be strings (which get converted to integers via the
             dictionaries), integers used directly, or slices.
@@ -134,6 +134,6 @@ class Concentrations:
         if isinstance(nuc, str):
             nuc_id = self.nuc_to_ind[nuc]
         else:
-            nuc_id = cell
+            nuc_id = nuc
 
         self.number[cell_id, nuc_id] = val

--- a/source/reaction_rates.py
+++ b/source/reaction_rates.py
@@ -75,7 +75,7 @@ class ReactionRates:
         if isinstance(nuc, str):
             nuc_id = self.nuc_to_ind[nuc]
         else:
-            nuc_id = cell
+            nuc_id = nuc
         if isinstance(react, str):
             react_id = self.react_to_ind[react]
         else:
@@ -105,7 +105,7 @@ class ReactionRates:
         if isinstance(nuc, str):
             nuc_id = self.nuc_to_ind[nuc]
         else:
-            nuc_id = cell
+            nuc_id = nuc
         if isinstance(react, str):
             react_id = self.react_to_ind[react]
         else:


### PR DESCRIPTION
It appears there is a potential bug in `__getitem__` and `__setitem__` for the `Concentrations` and `ReactionRates` classes; namely, if an integer is used for the nuclide index directly, it would actually receive the value for the cell.