### PR TITLE
Fixed issue with material name

### DIFF
--- a/opendeplete/openmc_wrapper.py
+++ b/opendeplete/openmc_wrapper.py
@@ -202,11 +202,6 @@ class Geometry:
         cells = self.geometry.get_all_material_cells()
         for cell in cells:
             name = cell.name
-
-            if name == '':
-                # Cell is not "physical", cycle.
-                continue
-
             number_densities, mat_ids = extract_openmc_materials(cell)
 
             for i, mat_id in enumerate(mat_ids):


### PR DESCRIPTION
This short PR ensures that only cells filled with materials are considered for depletion, while those filled with universes or lattices are ignored.