### PR TITLE
Fix results for far-chain nuclides

### DIFF
--- a/opendeplete/openmc_wrapper.py
+++ b/opendeplete/openmc_wrapper.py
@@ -338,6 +338,7 @@ class Geometry:
                 if key_nuc in self.participating_nuclides:
                     val = 1.0e-24*self.number_density[key_mat][key_nuc]
 
+                    # If nuclide is zero, do not add to the problem.
                     if val != 0.0:
                         if round_number:
                             val_magnitude = np.floor(np.log10(val))
@@ -346,7 +347,6 @@ class Geometry:
 
                             val = val_round * 10**val_magnitude
 
-                        # Do not add nuclide for performance reasons.
                         mat.add_nuclide(key_nuc, val)
 
             mat.set_density(units='sum')


### PR DESCRIPTION
In the older version of the code, if a nuclide didn't exist in ``total_number``, it didn't matter, because ``total_number`` itself gets written to disk.  

With the new HDF5 routines, if a nuclide doesn't exist until several timesteps in (think a dozen (n,gamma) reactions in a row), the Results dictionaries (formed from ``total_number``) may not contain the nuclide we need.  This causes ``__setitem__`` to fail.

This PR fixes this issue by forcing all nuclides that might exist now or in the future to exist in ``total_number`` after the first depletion sub-step.